### PR TITLE
Fix doc for Cldr.DateTime.Relative.to_string!

### DIFF
--- a/lib/cldr/datetime/relative.ex
+++ b/lib/cldr/datetime/relative.ex
@@ -212,7 +212,7 @@ defmodule Cldr.DateTime.Relative do
   end
 
   @doc """
-  Returns a `{:ok, string}` representing a relative time (ago, in) for a given
+  Returns a string representing a relative time (ago, in) for a given
   number, Date or Datetime or raises an exception on error.
 
   ## Arguments


### PR DESCRIPTION
I simply noticed a small incorrectness in the docs for `Cldr.DateTime.Relative.to_string!`.
The `@doc` says it returns an `{:ok, string}`, but it really just returns a string, so I corrected that.